### PR TITLE
Prepare initial PyPi release

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,61 @@
+# Licensing terms
+
+This project is licensed under the terms of the Modified BSD License
+(also known as New or Revised or 3-Clause BSD), as follows:
+
+- Copyright (c) 2001-2015, IPython Development Team
+- Copyright (c) 2015-, Jupyter Development Team
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the name of the Jupyter Development Team nor the names of its
+contributors may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+## About the Jupyter Development Team
+
+The Jupyter Development Team is the set of all contributors to the Jupyter project.
+This includes all of the Jupyter Subprojects, which are the different repositories
+under the [jupyter](https://github.com/jupyter/) GitHub organization.
+
+The core team that coordinates development on GitHub can be found here:
+https://github.com/jupyter/.
+
+## Our copyright policy
+
+Jupyter uses a shared copyright model. Each contributor maintains copyright
+over their contributions to Jupyter. But, it is important to note that these
+contributions are typically only changes to the repositories. Thus, the Jupyter
+source code, in its entirety is not the copyright of any single person or
+institution.  Instead, it is the collective copyright of the entire Jupyter
+Development Team.  If individual contributors want to maintain a record of what
+changes/contributions they have specific copyright on, they should indicate
+their copyright in the commit message of the change, when they commit the
+change to one of the Jupyter repositories.
+
+With this in mind, the following banner should be used in any source code file
+to indicate the copyright and license terms:
+
+    # Copyright (c) Jupyter Development Team.
+    # Distributed under the terms of the Modified BSD License.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.md

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 
+.PHONY: install uninstall dev clean check-env bdist sdist release
 .DEFAULT_GOAL=dev
 
 install:
@@ -22,4 +23,19 @@ dev: check-env
 		--log-level=DEBUG \
 		$(NB_OPTS)
 
-.PHONY: install uninstall dev
+clean: ## Make a clean source tree
+	rm -rf dist
+	rm -rf build
+	rm -rf *.egg-info
+
+bdist: ## Make a dist/*.whl binary distribution
+	python setup.py bdist_wheel $(POST_SDIST) \
+		&& rm -rf *.egg-info
+
+sdist: ## Make a dist/*.tar.gz source distribution
+	python setup.py sdist $(POST_SDIST) \
+		&& rm -rf *.egg-info
+
+release: POST_SDIST=upload
+release: bdist sdist ## Make a wheel + source release on PyPI
+

--- a/README.md
+++ b/README.md
@@ -21,13 +21,21 @@ jupyter serverextension list
 
 ## Install
 
-To install the **nb2kg** extension in an existing Notebook server environment:
+To install the _released_ **nb2kg** extension in an existing Notebook server environment:
 
 ```
-pip install "git+https://github.com/jupyter-incubator/nb2kg.git#egg=nb2kg&subdirectory=nb2kg"
+pip install nb2kg
+```
+
+To install the _latest_ **nb2kg** extension in an existing Notebook server environment:
+```
+pip install "git+https://github.com/jupyter-incubator/nb2kg.git#egg=nb2kg"
+```
+
+Once the package has been installed, it must then be registered as an extension:
+```
 jupyter serverextension enable --py nb2kg --sys-prefix
 ```
-
 ## Run Notebook server
 
 When you run the Notebook server with the **nb2kg** extension enabled, you must set the `KG_URL` environment variable to the URL of the kernel or enterprise gateway _and_ you must override the default kernel, kernel spec, and session managers:

--- a/nb2kg/_version.py
+++ b/nb2kg/_version.py
@@ -1,5 +1,5 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (0, 0, 1, 'dev')
+version_info = (0, 1, 0, 'dev')
 __version__ = '.'.join(map(str, version_info))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal=1
+
+[metadata]
+description-file=README.md

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,14 @@ setup_args = dict(
     name='nb2kg',
     author='Jupyter Development Team',
     author_email='jupyter@googlegroups.com',
-    description='Extension for Jupyter Notebook 4.2.x to enable remote kernels hosted by Kernel Gateway',
-    long_description = '''See `the README <https://github.com/jupyter/kernel_gateway_demos/nb2kg>`_ for more information.
+    description='Extension for Jupyter Notebook 4.2.x to enable remote kernels hosted by Kernel Gateway or Enterprise Gateway',
+    long_description = '''\
+NB2KG is a Jupyter Notebook extension for versions >= 4.2 that enables remote kernels hosted 
+by `Jupyter Kernel Gateway <https://pypi.org/project/jupyter_kernel_gateway>`_ 
+or `Jupyter Enterprise Gateway <https://pypi.org/project/jupyter_enterprise_gateway>`_.  
+See `README <https://github.com/jupyter-incubator/nb2kg>`_ for more information.
 ''',
-    url='https://github.com/jupyter/kernel_gateway_demos/nb2kg',
+    url='https://github.com/jupyter-incubator/nb2kg',
     version=VERSION_NS['__version__'],
     license='BSD',
     platforms=['Jupyter Notebook 4.2.x'],
@@ -41,10 +45,8 @@ setup_args = dict(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
     ]
 )
 


### PR DESCRIPTION
Since NB2KG is now its own incubator project, it makes sense to make
installation easier by adding the package to PyPi.  This will be done
via a `0.1.0` release (so the last digit can be used for fixes on top
of `0.0.1` - should that ever become necessary).  The changes follow
the model used by Jupyter Kernel Gateway.

Assuming I'm understanding the process, once these changes have been
merged, I will create a release entry in the GitHub repo, then upload
the bdist (wheel) and sdist (tar) files to PyPi.  I have already done
an initial upload to the pypi test index at: https://test.pypi.org/project/nb2kg/

Fixes #2
  