### PR TITLE
Don't pass username/password through to HTTP client when not set.

### DIFF
--- a/nb2kg/handlers.py
+++ b/nb2kg/handlers.py
@@ -31,8 +31,8 @@ KG_CLIENT_KEY = os.getenv('KG_CLIENT_KEY')
 KG_CLIENT_CERT = os.getenv('KG_CLIENT_CERT')
 KG_CLIENT_CA = os.getenv('KG_CLIENT_CA')
 
-KG_HTTP_USER = os.getenv('KG_HTTP_USER', '')
-KG_HTTP_PASS = os.getenv('KG_HTTP_PASS', '')
+KG_HTTP_USER = os.getenv('KG_HTTP_USER')
+KG_HTTP_PASS = os.getenv('KG_HTTP_PASS')
 
 # Get env variables to handle timeout of request and connection
 KG_CONNECT_TIMEOUT = float(os.getenv('KG_CONNECT_TIMEOUT', 20.0))

--- a/nb2kg/handlers.py
+++ b/nb2kg/handlers.py
@@ -121,11 +121,13 @@ class KernelGatewayWSClient(LoggingConfigurable):
         parameters = {
           "headers" : KG_HEADERS,
           "validate_cert" : VALIDATE_KG_CERT,
-          "auth_username" : KG_HTTP_USER, 
-          "auth_password" : KG_HTTP_PASS,
           "connect_timeout" : KG_CONNECT_TIMEOUT,
           "request_timeout" : KG_REQUEST_TIMEOUT
         }
+        if KG_HTTP_USER:
+            parameters["auth_username"] = KG_HTTP_USER
+        if KG_HTTP_PASS:
+            parameters["auth_password"] = KG_HTTP_PASS
         if KG_CLIENT_KEY:
             parameters["client_key"] = KG_CLIENT_KEY
             parameters["client_cert"] = KG_CLIENT_CERT

--- a/nb2kg/managers.py
+++ b/nb2kg/managers.py
@@ -47,8 +47,10 @@ def load_connection_args(**kwargs):
     kwargs['request_timeout'] = kwargs.get('request_timeout', KG_REQUEST_TIMEOUT)
     kwargs['headers'] = kwargs.get('headers', KG_HEADERS)
     kwargs['validate_cert'] = kwargs.get('validate_cert', VALIDATE_KG_CERT)
-    kwargs['auth_username'] = kwargs.get('auth_username', KG_HTTP_USER)
-    kwargs['auth_password'] = kwargs.get('auth_password', KG_HTTP_PASS)
+    if KG_HTTP_USER:
+        kwargs['auth_username'] = kwargs.get('auth_username', KG_HTTP_USER)
+    if KG_HTTP_PASS:
+        kwargs['auth_password'] = kwargs.get('auth_password', KG_HTTP_PASS)
     return kwargs
 
 @gen.coroutine

--- a/nb2kg/managers.py
+++ b/nb2kg/managers.py
@@ -30,8 +30,8 @@ KG_CLIENT_KEY = os.getenv('KG_CLIENT_KEY')
 KG_CLIENT_CERT = os.getenv('KG_CLIENT_CERT')
 KG_CLIENT_CA = os.getenv('KG_CLIENT_CA')
 
-KG_HTTP_USER = os.getenv('KG_HTTP_USER', '')
-KG_HTTP_PASS = os.getenv('KG_HTTP_PASS', '')
+KG_HTTP_USER = os.getenv('KG_HTTP_USER')
+KG_HTTP_PASS = os.getenv('KG_HTTP_PASS')
 
 KG_CONNECT_TIMEOUT = float(os.getenv('KG_CONNECT_TIMEOUT', 20.0))
 KG_REQUEST_TIMEOUT = float(os.getenv('KG_REQUEST_TIMEOUT', 20.0))


### PR DESCRIPTION
As per #6, this PR addresses issue where username/password get passed through to HTTP client even when not set, meaning that ``Authorization`` header for ``token`` gets overridden with ``basic`` authentication header with empty username/password values.