### PR TITLE
Fix running kernels display

### DIFF
--- a/nb2kg/managers.py
+++ b/nb2kg/managers.py
@@ -441,11 +441,14 @@ class SessionManager(BaseSessionManager):
 
         model = {
             'id': row['session_id'],
-            'notebook': {
-                'path': row['path']
-            },
+            'path': row['path'],
+            'name': row['name'],
+            'type': row['type'],
             'kernel': kernel
         }
+        if row['type'] == 'notebook':  # Provide the deprecated API.
+            model['notebook'] = {'path': row['path'], 'name': row['name']}
+
         raise gen.Return(model)
 
     @gen.coroutine


### PR DESCRIPTION
After further analysis it turns out that Notebook versions > `5.0.0`
exhibit this problem.  This issue started happening once Notebook [PR
2559](https://github.com/jupyter/notebook/pull/2559/files) was submitted
for `5.1.0.rc1` to distinguish notebook instances from other active
"sessions" that can also reside in the session table.  What is used
by the java-script to set the 'Running' indicator is produced by the
`row_to_model()` method.

nb2kg was still using the older model definition that did not include
the `type` value.  As a result, notebook sessions (i.e., active kernels)
were not getting displayed.

This change brings the model used in nb2kg up to date, thereby enabling
the proper display of active kernels.  At some point, we should figure
out a way to leverage the superclass method, but nb2kg uses futures
that, when attempting to remove, caused issues upstream.

Fixes #8