### PR TITLE
Convey working directory of notebook

### DIFF
--- a/nb2kg/managers.py
+++ b/nb2kg/managers.py
@@ -140,6 +140,10 @@ class RemoteKernelManager(MappingKernelManager):
             self.log.info("Request new kernel at: %s" % self.kernels_endpoint)
             kernel_env = {k: v for (k, v) in dict(os.environ).items() if k.startswith('KERNEL_')
                         or k in os.environ.get('KG_ENV_WHITELIST', '').split(",")}
+            # Convey the full path to where this notebook file is located.
+            if path is not None and kernel_env.get('KERNEL_WORKING_DIR') is None:
+                kernel_env['KERNEL_WORKING_DIR'] = self.cwd_for_path(path)
+
             json_body = json_encode({'name': kernel_name, 'env': kernel_env})
 
             response = yield fetch_kg(self.kernels_endpoint, method='POST', body=json_body)


### PR DESCRIPTION
When communicating with a Gateway that launches container-based kernels,
it is desirable to mirror the notebook's working directory in cases where
the container is sharing the notebook directory's volume.  This is a
common configuration in Jupyter Hub installations running on Kubernetes
where the Notebook/Lab instance enables the mounting of the user's home
directory and those same mounts are used via the Enterprise Gateway
kernel images.  This change adds `KERNEL_WORKING_DIR` to the json body
of the kernel creation request which enables the receiving Gateway to
potentially act on that value when launching kernel images.