### PR TITLE
Inconsistent behavior between WebSocketChannelsHandler and others

### DIFF
--- a/nb2kg/handlers.py
+++ b/nb2kg/handlers.py
@@ -46,6 +46,9 @@ class WebSocketChannelsHandler(WebSocketHandler, IPythonHandler):
     gateway = None
     kernel_id = None
 
+    def check_origin(self, origin=None):
+        return IPythonHandler.check_origin(self, origin)
+
     def set_default_headers(self):
         """Undo the set_default_headers in IPythonHandler which doesn't make sense for websockets"""
         pass


### PR DESCRIPTION
Fix the inconsistent behavior between WebSocketChannelsHandler and the other Handlers when using NotebookApp.allow_origin configuration. The WebSocketChannelsHandler uses the `check_origin` method from WebSocketHandler by default.

The problem is discovered by following steps:

I'm using nb2kg with Jupyter Notebook to launch kernels on spark. The notebook server runs behind an nginx proxy. 
The NotebookApp.allow_origin was set as:
`c.NotebookApp.allow_origin = '*'`
However, the server returned 403 when the frontend connected to the successfully created kernel. 
The server showed the following logs:
`[D 12:54:07.104 NotebookApp] Initializing websocket connection /api/kernels/50852902-0ffe-4973-b550-a2424bf4f86d/channels
[W 12:54:07.108 NotebookApp] 403 GET /api/kernels/50852902-0ffe-4973-b550-a2424bf4f86d/channels?session_id=E5BB1B111B8D4B4DAF798597772E5578 (10.244.0.91) 4.93ms referer=None
[D 12:54:07.109 NotebookApp] Cross origin websockets not allowed`