### PR TITLE
Changes necessary to coexist with Tornado 6

### DIFF
--- a/nb2kg/handlers.py
+++ b/nb2kg/handlers.py
@@ -84,7 +84,7 @@ class WebSocketChannelsHandler(WebSocketHandler, IPythonHandler):
     def get(self, kernel_id, *args, **kwargs):
         self.authenticate()
         self.kernel_id = cast_unicode(kernel_id, 'ascii')
-        super(WebSocketChannelsHandler, self).get(kernel_id=kernel_id, *args, **kwargs)
+        yield gen.maybe_future(super(WebSocketChannelsHandler, self).get(kernel_id=kernel_id, *args, **kwargs))
 
     def open(self, kernel_id, *args, **kwargs):
         """Handle web socket connection open to notebook server and delegate to gateway web socket handler """


### PR DESCRIPTION
The current Tornado 6 release uses native coroutines for its websocket handler.  As a result, subclasses that didn't call via `yield` or `await` now fail.  This change fixes that handler accordingly.