### PR TITLE
Allow KG_HEADERS to specify Authorization without being overwritten 

### DIFF
--- a/nb2kg/handlers.py
+++ b/nb2kg/handlers.py
@@ -24,9 +24,10 @@ from traitlets.config.configurable import LoggingConfigurable
 # for a server extension.
 KG_URL = os.getenv('KG_URL', 'http://127.0.0.1:8888/')
 KG_HEADERS = json.loads(os.getenv('KG_HEADERS', '{}'))
-KG_HEADERS.update({
-    'Authorization': 'token {}'.format(os.getenv('KG_AUTH_TOKEN', ''))
-})
+if 'Authorization' not in KG_HEADERS.keys():
+    KG_HEADERS.update({
+        'Authorization': 'token {}'.format(os.getenv('KG_AUTH_TOKEN', ''))
+    })
 VALIDATE_KG_CERT = os.getenv('VALIDATE_KG_CERT') not in ['no', 'false']
 
 KG_CLIENT_KEY = os.getenv('KG_CLIENT_KEY')

--- a/nb2kg/managers.py
+++ b/nb2kg/managers.py
@@ -21,9 +21,10 @@ from traitlets import Instance, Unicode, default
 # for a server extension.
 KG_URL = os.getenv('KG_URL', 'http://127.0.0.1:8888/')
 KG_HEADERS = json.loads(os.getenv('KG_HEADERS', '{}'))
-KG_HEADERS.update({
-    'Authorization': 'token {}'.format(os.getenv('KG_AUTH_TOKEN', ''))
-})
+if 'Authorization' not in KG_HEADERS.keys():
+    KG_HEADERS.update({
+        'Authorization': 'token {}'.format(os.getenv('KG_AUTH_TOKEN', ''))
+    })
 VALIDATE_KG_CERT = os.getenv('VALIDATE_KG_CERT') not in ['no', 'false']
 
 KG_CLIENT_KEY = os.getenv('KG_CLIENT_KEY')


### PR DESCRIPTION
https://github.com/jupyter/nb2kg/issues/28

Currently if `KG_HEADERS` Includes an `Authorization: ` header, it always be replaced by and empty token: `Authorization: token `

This PR attempts to keep the existing functionality when `KG_HEADERS` does not include `Authorization` by

1. Loading `KG_HEADERS`
2. If `Authorization` was NOT present in the KG_HEADERS, this maintains the existing functionality of creating in the `Authorization: token $KG_AUTH_TOKEN` even if `KG_AUTH_TOKEN` is empty string


Tested using Apache Knox 1.2 w/ JWT Authentication. This uses the form `{'Authorization': "Bearer '${authToken}'"}`


```
dsxl="${topology}.fyre.ibm.com:31843"
gateway="${knoxhost}:8443/gateway/${topology}"
authToken="$(curl -k -X GET https://$dsxl/v1/preauth/validateAuth -u $user:$password 2> /dev/null | grep -o "accessToken\":\".*\",\"_" | grep -o ":\".*" | grep -o ".*\"," | awk -F\" '{print $2}')"

docker run -t --rm \
--name localnb2kg \
-p 8888:8888 \
-e KG_URL="https://${gateway}/jkg" \
-e KG_WS_URL="wss://${gateway}/jkgws"  \
-e VALIDATE_KG_CERT=no \
-e KG_HEADERS='{"Authorization": "Bearer '${authToken}'"}' \
-e KERNEL_EXTRA_SPARK_OPTS='--archives hdfs:///user/dsxhi/environments/x86_glibc2_17.tar.gz --conf spark.yarn.appMasterEnv.PYSPARK_PYTHON=x86_glibc2_17.tar.gz/x86_glibc2_17/bin/python --conf spark.executor.memory=1g' \
nb2kg:2.0.0.iss28
```

+ A few smoketests preserving original functionality 
![image](https://user-images.githubusercontent.com/9003246/55604337-125c7880-5724-11e9-94cf-ccdb81d0889a.png)
