### PR TITLE
Increase http timeout default values

### DIFF
--- a/nb2kg/handlers.py
+++ b/nb2kg/handlers.py
@@ -38,8 +38,8 @@ KG_HTTP_USER = os.getenv('KG_HTTP_USER')
 KG_HTTP_PASS = os.getenv('KG_HTTP_PASS')
 
 # Get env variables to handle timeout of request and connection
-KG_CONNECT_TIMEOUT = float(os.getenv('KG_CONNECT_TIMEOUT', 20.0))
-KG_REQUEST_TIMEOUT = float(os.getenv('KG_REQUEST_TIMEOUT', 20.0))
+KG_CONNECT_TIMEOUT = float(os.getenv('KG_CONNECT_TIMEOUT', 60.0))
+KG_REQUEST_TIMEOUT = float(os.getenv('KG_REQUEST_TIMEOUT', 60.0))
 
 # Keepalive ping interval (default: 30 seconds)
 KG_WS_PING_INTERVAL_SECS = int(os.getenv('KG_WS_PING_INTERVAL_SECS', 30))

--- a/nb2kg/managers.py
+++ b/nb2kg/managers.py
@@ -34,8 +34,8 @@ KG_CLIENT_CA = os.getenv('KG_CLIENT_CA')
 KG_HTTP_USER = os.getenv('KG_HTTP_USER')
 KG_HTTP_PASS = os.getenv('KG_HTTP_PASS')
 
-KG_CONNECT_TIMEOUT = float(os.getenv('KG_CONNECT_TIMEOUT', 20.0))
-KG_REQUEST_TIMEOUT = float(os.getenv('KG_REQUEST_TIMEOUT', 20.0))
+KG_CONNECT_TIMEOUT = float(os.getenv('KG_CONNECT_TIMEOUT', 60.0))
+KG_REQUEST_TIMEOUT = float(os.getenv('KG_REQUEST_TIMEOUT', 60.0))
 
 
 def load_connection_args(**kwargs):


### PR DESCRIPTION
The current defaults are 20 seconds which matches the defaults imposed
by tornado.  Since it doesn't hurt to increase these and since many
kernel starts take just around 20-30 seconds in Yarn clusters, etc.,
it is better to have these values be longer - so this PR increases them
to 60 seconds.  This also allows server-side kernel startup issues to
occur that might have otherwise happened after the previous default or
the kernel startup succeed only to have the request timeout.